### PR TITLE
Added tags to orders, with TradingAgent support.

### DIFF
--- a/agent/TradingAgent.py
+++ b/agent/TradingAgent.py
@@ -285,8 +285,8 @@ class TradingAgent(FinancialAgent):
   # string (valid symbol), int (positive share quantity), bool (True == BUY), int (price in cents).
   # The call may optionally specify an order_id (otherwise global autoincrement is used) and
   # whether cash or risk limits should be enforced or ignored for the order.
-  def placeLimitOrder (self, symbol, quantity, is_buy_order, limit_price, order_id=None, ignore_risk = True):
-    order = LimitOrder(self.id, self.currentTime, symbol, quantity, is_buy_order, limit_price, order_id)
+  def placeLimitOrder (self, symbol, quantity, is_buy_order, limit_price, order_id=None, ignore_risk = True, tag = None):
+    order = LimitOrder(self.id, self.currentTime, symbol, quantity, is_buy_order, limit_price, order_id, tag)
 
     if quantity > 0:
       # Test if this order can be permitted given our at-risk limits.
@@ -321,7 +321,7 @@ class TradingAgent(FinancialAgent):
     else:
       log_print ("TradingAgent ignored limit order of quantity zero: {}", order)
 
-  def placeMarketOrder(self, symbol, direction, quantity, ignore_risk=True):
+  def placeMarketOrder(self, symbol, direction, quantity, ignore_risk=True, tag = None):
     """
     Used by any Trading Agent subclass to place a market order. The market order is created as multiple limit orders
     crossing the spread walking the book until all the quantities are matched.
@@ -362,7 +362,7 @@ class TradingAgent(FinancialAgent):
       log_print(f'[---- {self.name} - {self.currentTime} ----]: PLACING 1 MARKET ORDER AS MULTIPLE LIMIT ORDERS')
       for quote in quotes.items():
           p, q = quote[0], quote[1]
-          self.placeLimitOrder(symbol, quantity=q, is_buy_order=direction=='BUY', limit_price=p)
+          self.placeLimitOrder(symbol, quantity=q, is_buy_order=direction=='BUY', limit_price=p, tag=tag)
           log_print(f'[---- {self.name} - {self.currentTime} ----]: LIMIT ORDER PLACED - {q} @ {p}')
     else:
       log_print(f"TradingAgent ignored market order of quantity zero: {symbol} {direction} {quantity}")

--- a/util/order/LimitOrder.py
+++ b/util/order/LimitOrder.py
@@ -13,8 +13,8 @@ silent_mode = False
 class LimitOrder (Order):
 
 
-  def __init__ (self, agent_id, time_placed, symbol, quantity, is_buy_order, limit_price, order_id=None):
-    super().__init__(agent_id, time_placed, symbol, quantity, is_buy_order, order_id)
+  def __init__ (self, agent_id, time_placed, symbol, quantity, is_buy_order, limit_price, order_id=None, tag=None):
+    super().__init__(agent_id, time_placed, symbol, quantity, is_buy_order, order_id, tag=tag)
 
     # The limit price is the minimum price the agent will accept (for a sell order) or
     # the maximum price the agent will pay (for a buy order).
@@ -29,7 +29,8 @@ class LimitOrder (Order):
     # Until we make explicit market orders, we make a few assumptions that EXTREME prices on limit
     # orders are trying to represent a market order.  This only affects printing - they still hit
     # the order book like limit orders, which is wrong.
-    return "(Agent {} @ {}) : {} {} {} @ {}{}".format(self.agent_id, Kernel.fmtTime(self.time_placed),
+    return "(Agent {} @ {}{}) : {} {} {} @ {}{}".format(self.agent_id, Kernel.fmtTime(self.time_placed),
+                                                      f" [{self.tag}]" if self.tag is not None else "",
                                                       "BUY" if self.is_buy_order else "SELL", self.quantity, self.symbol,
                                                       dollarize(self.limit_price) if abs(self.limit_price) < sys.maxsize else 'MKT', filled)
 

--- a/util/order/Order.py
+++ b/util/order/Order.py
@@ -7,7 +7,7 @@ class Order:
   order_id = 0
   _order_ids = []
 
-  def __init__(self, agent_id, time_placed, symbol, quantity, is_buy_order, order_id=None):
+  def __init__(self, agent_id, time_placed, symbol, quantity, is_buy_order, order_id=None, tag=None):
     self.agent_id = agent_id
 
     # Time at which the order was created by the agent.
@@ -31,6 +31,14 @@ class Order:
     # class that adds these later?)
     self.fill_price = None
 
+    # Tag: a free-form user-defined field that can contain any information relevant to the
+    #      entity placing the order.  Recommend keeping it alphanumeric rather than
+    #      shoving in objects, as it will be there taking memory for the lifetime of the
+    #      order and in all logging mechanisms.  Intent: for strategy agents to set tags
+    #      to help keep track of the intent of particular orders, to simplify their code.
+    self.tag = tag
+
+
   def generateOrderId(self):
     # generates a unique order ID if the order ID is not specified
     if not Order.order_id in Order._order_ids:
@@ -39,3 +47,5 @@ class Order:
       Order.order_id += 1
       oid = self.generateOrderId()
     return oid
+
+


### PR DESCRIPTION
Added tag attribute to Order, LimitOrder, TradingAgent.placeLimitOrder, TradingAgent.placeMarketOrder.

Tags passed to placeMarketOrder will be applied to all resulting limit orders if the market order is split.

Tags don't do anything.  They are printed as part of the __str__ or __repr__ formatting, and are available to read out of the order for agents that care to.

The intention is for strategy agents to be able to mark orders with (for example) a purpose, which can then simplify the agents code.  (e.g. so later when it looks through self.orders, it can see which were its "bracketing" orders, or which were its "positioning" orders, or which were its "spoofing" orders, etc)