### PR TITLE
Changed Kernel.agent_saved_states too Kernel.custom_state

### DIFF
--- a/Kernel.py
+++ b/Kernel.py
@@ -57,7 +57,13 @@ class Kernel:
     # agents must be a list of agents for the simulation,
     #        based on class agent.Agent
     self.agents = agents
-    self.agent_saved_states = [None] * len(self.agents)
+
+    # Simulation custom state in a freeform dictionary.  Allows config files
+    # that drive multiple simulations, or require the ability to generate
+    # special logs after simulation, to obtain needed output without special
+    # case code in the Kernel.  Per-agent state should be handled using the
+    # provided updateAgentState() method.
+    self.custom_state = {}
 
     # The kernel start and stop time (first and last timestamp in
     # the simulation, separate from anything like exchange open/close).
@@ -308,7 +314,7 @@ class Kernel:
 
     print ("Simulation ending!")
 
-    return self.agent_saved_states
+    return self.custom_state
 
 
   def sendMessage(self, sender = None, recipient = None, msg = None, delay = 0):
@@ -515,8 +521,17 @@ class Kernel:
     dfLog.to_pickle(os.path.join(path, file), compression='bz2')
 
 
-  def saveState (self, agent_id, state):
-    self.agent_saved_states[agent_id] = state
+  def updateAgentState (self, agent_id, state):
+    """ Called by an agent that wishes to replace its custom state in the dictionary
+        the Kernel will return at the end of simulation.  Shared state must be set directly,
+        and agents should coordinate that non-destructively.
+
+        Note that it is never necessary to use this kernel state dictionary for an agent
+        to remember information about itself, only to report it back to the config file.
+    """
+
+    if 'agent_state' not in self.custom_state: self.custom_state['agent_state'] = {}
+    self.custom_state['agent_state'][agent_id] = state
 
  
   @staticmethod

--- a/agent/Agent.py
+++ b/agent/Agent.py
@@ -164,8 +164,15 @@ class Agent:
   def writeLog (self, dfLog, filename=None):
     self.kernel.writeLog(self.id, dfLog, filename)
 
-  def saveState (self, state):
-    self.kernel.saveState(self.id, state)
+  def updateAgentState (self, state):
+    """ Agents should use this method to replace their custom state in the dictionary
+        the Kernel will return to the experimental config file at the end of the
+        simulation.  This is intended to be write-only, and agents should not use
+        it to store information for their own later use.
+    """
+
+    self.kernel.updateAgentState(self.id, state)
+
 
   ### Internal methods that should not be modified without a very good reason.
 

--- a/agent/examples/QLearningAgent.py
+++ b/agent/examples/QLearningAgent.py
@@ -37,11 +37,11 @@ class QLearningAgent(TradingAgent):
 
 
 
-  # During kernelStopping, give the Kernel our saved_state for potential
+  # During kernelStopping, give the Kernel our saved state for potential
   # subsequent simulations during the same experiment.
   def kernelStopping (self):
     super().kernelStopping()
-    self.saveState(self.qtable)
+    self.updateAgentState(self.qtable)
 
 
   def wakeup (self, currentTime):

--- a/config/loop_obi.py
+++ b/config/loop_obi.py
@@ -166,8 +166,6 @@ for i in range(num_mom):
 
 num_agents = num_exch + num_zi + num_obi + num_val + num_mm + num_mom
 
-agent_saved_states = [None] * num_agents
-
 
 ### SIMULATION CONTROL SETTINGS.
 
@@ -440,7 +438,7 @@ for sim in range(num_consecutive_simulations):   # eventually make this a stoppi
                 defaultComputationDelay = defaultComputationDelay,
                 oracle = oracle, log_dir = "{}_{}".format(log_dir,sim))
 
-  obi_perf.append(agent_saved_states[0])
+  obi_perf.append(agent_saved_states['agent_state'][0])
 
   print ("\n====== Experimental wallclock elapsed: {} ======\n".format(
                                   pd.Timestamp('now') - wallclock_start))

--- a/config/qlearning.py
+++ b/config/qlearning.py
@@ -122,7 +122,8 @@ for i in range(num_qlearners):
 
 num_agents = num_exch + num_zi + num_qlearners
 
-agent_saved_states = [None] * num_agents
+agent_saved_states = {}
+agent_saved_states['agent_state'] = [None] * num_agents
 
 
 ### SIMULATION CONTROL SETTINGS.
@@ -334,13 +335,13 @@ for sim in range(num_consecutive_simulations):   # eventually make this a stoppi
 
   # Add a QLearning agent to try to beat this market.
   for i in range(num_qlearners):
-    if agent_saved_states[agent_id] is None:
+    if agent_saved_states['agent_state'][agent_id] is None:
       random_state = get_rand_obj(agent_seeds[agent_id])
       qtable = QTable(dims = (2201, 3), alpha = 0.99, alpha_decay = 0.999,
                 alpha_min = 0, epsilon = 0.99, epsilon_decay = 0.999, epsilon_min = 0,
                 gamma = 0.98, random_state = random_state)
     else:
-      qtable = agent_saved_states[agent_id]
+      qtable = agent_saved_states['agent_state'][agent_id]
 
     agents.extend([ QLearningAgent(agent_id, "QLearning Agent {}".format(agent_id), "QLearningAgent", starting_cash = starting_cash, qtable = qtable, random_state = random_state) ])
     agent_id += 1


### PR DESCRIPTION
Broadened Kernel.agent_saved_states concept into Kernel.custom_state, updated terminology to match, and updated the one agent and two configs affected by the change.