### PR TITLE
`log_orders` param for trading agents more intuitive

### DIFF
--- a/agent/Agent.py
+++ b/agent/Agent.py
@@ -5,7 +5,7 @@ from util.util import log_print
 
 class Agent:
 
-  def __init__ (self, id, name, type, random_state):
+  def __init__ (self, id, name, type, random_state, log_events=True):
 
     # ID must be a unique number (usually autoincremented).
     # Name is for human consumption, should be unique (often type + number).
@@ -17,6 +17,7 @@ class Agent:
     self.name = name
     self.type = type
     self.random_state = random_state
+    self.log_events = log_events
 
     if not random_state:
       raise ValueError("A valid, seeded np.random.RandomState object is required " +
@@ -89,7 +90,7 @@ class Agent:
 
     # If this agent has been maintaining a log, convert it to a Dataframe
     # and request that the Kernel write it to disk before terminating.
-    if self.log:
+    if self.log and self.log_events:
       dfLog = pd.DataFrame(self.log)
       dfLog.set_index('EventTime', inplace=True)
       self.writeLog(dfLog)

--- a/agent/ExchangeAgent.py
+++ b/agent/ExchangeAgent.py
@@ -26,8 +26,7 @@ class ExchangeAgent(FinancialAgent):
   def __init__(self, id, name, type, mkt_open, mkt_close, symbols, book_freq='S', wide_book=False, pipeline_delay = 40000,
                computation_delay = 1, stream_history = 0, log_orders = False, random_state = None):
 
-    super().__init__(id, name, type, random_state)
-
+    super().__init__(id, name, type, random_state, log_events=log_orders)
     # Do not request repeated wakeup calls.
     self.reschedule = False
 

--- a/agent/FinancialAgent.py
+++ b/agent/FinancialAgent.py
@@ -10,9 +10,9 @@ import traceback
 # exchanges to make this more useful later on.
 class FinancialAgent(Agent):
 
-  def __init__(self, id, name, type, random_state):
+  def __init__(self, id, name, type, random_state, log_events):
     # Base class init.
-    super().__init__(id, name, type, random_state)
+    super().__init__(id, name, type, random_state, log_events)
 
   # Used by any subclass to dollarize an int-cents price for printing.
   def dollarize (self, cents):

--- a/agent/TradingAgent.py
+++ b/agent/TradingAgent.py
@@ -17,7 +17,7 @@ class TradingAgent(FinancialAgent):
 
   def __init__(self, id, name, type, random_state=None, starting_cash=100000, log_orders=False):
     # Base class init.
-    super().__init__(id, name, type, random_state)
+    super().__init__(id, name, type, random_state, log_events=log_orders)
 
     # We don't yet know when the exchange opens or closes.
     self.mkt_open = None


### PR DESCRIPTION
Creates following behaviour change: `log_orders=False` for Exchange and Trading Agents means no log file created at all.

This was because the following issue was observed: even for trading agents with `log_orders=False`, a log file was still created (with nothing in it). For simulations with many agents, this causes many disk writes, incurring significant slowdown. Now the file is only created for agents when `log_order=True` as one might expect. 