### PR TITLE
Agent logging update

### DIFF
--- a/agent/Agent.py
+++ b/agent/Agent.py
@@ -5,7 +5,7 @@ from util.util import log_print
 
 class Agent:
 
-  def __init__ (self, id, name, type, random_state):
+  def __init__ (self, id, name, type, random_state, log_to_file=True):
 
     # ID must be a unique number (usually autoincremented).
     # Name is for human consumption, should be unique (often type + number).
@@ -16,6 +16,7 @@ class Agent:
     self.id = id
     self.name = name
     self.type = type
+    self.log_to_file = log_to_file
     self.random_state = random_state
 
     if not random_state:
@@ -89,7 +90,7 @@ class Agent:
 
     # If this agent has been maintaining a log, convert it to a Dataframe
     # and request that the Kernel write it to disk before terminating.
-    if self.log:
+    if self.log and self.log_to_file:
       dfLog = pd.DataFrame(self.log)
       dfLog.set_index('EventTime', inplace=True)
       self.writeLog(dfLog)

--- a/agent/TradingAgent.py
+++ b/agent/TradingAgent.py
@@ -23,8 +23,13 @@ class TradingAgent(FinancialAgent):
     self.mkt_open = None
     self.mkt_close = None
 
-    # Log all order activity?
+    # Log order activity?
     self.log_orders = log_orders
+
+    # Log all activity to file?
+    if log_orders is None:
+      self.log_orders = False
+      self.log_to_file = False
 
     # Store starting_cash in case we want to refer to it for performance stats.
     # It should NOT be modified.  Use the 'CASH' key in self.holdings.

--- a/config/exp_agent_demo.py
+++ b/config/exp_agent_demo.py
@@ -104,7 +104,7 @@ util.silent_mode = not args.verbose
 LimitOrder.silent_mode = not args.verbose
 
 exchange_log_orders = True
-log_orders = False
+log_orders = None
 book_freq = 0
 
 simulation_start_time = dt.datetime.now()

--- a/config/rmsc03.py
+++ b/config/rmsc03.py
@@ -137,7 +137,7 @@ util.silent_mode = not args.verbose
 LimitOrder.silent_mode = not args.verbose
 
 exchange_log_orders = True
-log_orders = False
+log_orders = None
 book_freq = 0
 
 simulation_start_time = dt.datetime.now()


### PR DESCRIPTION
Made following changes:

  - Added `log_to_file=True` keyword argument to Agent class to allow suppression of logging of
individual agent events to file for speed reasons.
  - Added `log_orders=None` option to TradingAgent as a shorthand for
`log_orders=False and log_to_file=False`.
  - Updated relevant (tutorial) configs.