### PR TITLE
changed return and surplus according to wiki definition

### DIFF
--- a/cli/read_agent_logs.py
+++ b/cli/read_agent_logs.py
@@ -47,8 +47,8 @@ for log_dir in log_dirs:
       fcp = df.loc[df['EventType'] == 'FINAL_CASH_POSITION', 'Event'][0]
       fv = df.loc[df['EventType'] == 'MARKED_TO_MARKET', 'Event'][0]
 
-      ret = ec - sc
-      surp = fcp - sc + fv
+      ret = fcp - sc
+      surp = fv - sc
       stats.append({ 'AgentType' : at, 'Return' : ret, 'Surplus' : surp })
     except (IndexError, KeyError):
       continue


### PR DESCRIPTION
According to the wiki: The return is the difference between the initial and final cash positions of the agent. The surplus is the difference of the agent's initial cash position from its final holdings (cash + shares marked to the final market price). 

In Trading Agent, we can see that: 
line128: EndCash (ec) is equal to the MarkedToMarker, equal to cash + value of the held shares
line123: FinalCashPosition (fcp) is equal to the cash only 

changed the computation in the code according to the wiki definition