### PR TITLE
Fix Windows Compatability Issue

### DIFF
--- a/config/rmsc01.py
+++ b/config/rmsc01.py
@@ -230,7 +230,7 @@ defaultComputationDelay = 50  # 50 nanoseconds
 
 # LATENCY
 
-latency_rstate = np.random.RandomState(seed=np.random.randint(low=0, high=2**32))
+latency_rstate = np.random.RandomState(seed=np.random.randint(low=0, high=2**32, dtype='uint64'))
 pairwise = (agent_count, agent_count)
 
 # All agents sit on line from Seattle to NYC


### PR DESCRIPTION
Specify a dtype in np.random.RandomState. Without this specification windows assumes it is a 32 bit type and will generate overflow errors and crash.

It's pretty clear this was an oversight since other calls to randint specify this dtype.