### PR TITLE
Noise calculation error fix

### DIFF
--- a/Kernel.py
+++ b/Kernel.py
@@ -377,7 +377,7 @@ class Kernel:
                  self.fmtTime(deliverAt))
     else:
       latency = self.agentLatency[sender][recipient]
-      noise = self.random_state.choice(len(self.latencyNoise), 1, self.latencyNoise)[0]
+      noise = self.random_state.choice(len(self.latencyNoise), p=self.latencyNoise)
       deliverAt = sentTime + pd.Timedelta(latency + noise)
       log_print ("Kernel applied latency {}, noise {}, accumulated delay {}, one-time delay {} on sendMessage from: {} to {}, scheduled for {}",
                  latency, noise, self.currentAgentAdditionalDelay, delay, self.agents[sender].name, self.agents[recipient].name,


### PR DESCRIPTION
- __Expected behaviour__

  `numpy.random.RandomState` object samples noise value from the __distribution defined by the array of probabilities__ `self.latencyNoise`, which index `i` means the very value and `self.latencyNoise[i]` means the probability of getting such a value.

- __Actual behaviour__

  `numpy.random.RandomState` object samples noise value from the __Discrete uniform distribution__ inside `[0, len(self.latencyNoise) - 1]`.

- __Why does it happen__

  This happens due to incorrect passing of arguments to the method `self.random.RandomState.choice` that has the [following](https://numpy.org/doc/stable/reference/random/generated/numpy.random.RandomState.choice.html) signature: `random.RandomState.choice(a, size=None, replace=True, p=None)`.

  As you can see, `self.latencyNoise` should be passed with the keyword `p` or as the fourth argument — not third, in which case it is interpreted as `True` boolean. You can also omit the `size` parameter, because you only want to get one value per method call.